### PR TITLE
Add CE toughness tuning for Aya weapons

### DIFF
--- a/Patches/Chaoura Race/ThingDefs_Misc/Weapons.xml
+++ b/Patches/Chaoura Race/ThingDefs_Misc/Weapons.xml
@@ -30,6 +30,14 @@
 					</value>
 				</li>
 
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="HAR_CO_Weapon_a"]/statBases</xpath>
+					<value>
+						<Bulk>1</Bulk>
+						<ToughnessRating>4</ToughnessRating>
+					</value>
+				</li>
+
 				
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="HAR_CO_Weapon_b"]/tools</xpath>
@@ -69,6 +77,14 @@
 					</value>
 				</li>
 
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="HAR_CO_Weapon_b"]/statBases</xpath>
+					<value>
+						<Bulk>10</Bulk>
+						<StuffEffectMultiplierToughness>6.325</StuffEffectMultiplierToughness>
+					</value>
+				</li>
+
 				
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ThingDef[defName="HAR_CO_Weapon_c"]/tools</xpath>
@@ -105,6 +121,14 @@
 								<armorPenetrationBlunt>1.28</armorPenetrationBlunt>
 							</li>
 						</tools>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="HAR_CO_Weapon_c"]/statBases</xpath>
+					<value>
+						<Bulk>8</Bulk>
+						<StuffEffectMultiplierToughness>5.657</StuffEffectMultiplierToughness>
 					</value>
 				</li>
 

--- a/Patches/Chaoura Race/ThingDefs_Races/AlienRace_Chaoura.xml
+++ b/Patches/Chaoura Race/ThingDefs_Races/AlienRace_Chaoura.xml
@@ -53,6 +53,7 @@
           <value>
             <Suppressability>1</Suppressability>
             <SmokeSensitivity>1.2</SmokeSensitivity>
+            <NightVisionEfficiency>1.0</NightVisionEfficiency>
           </value>
         </li>
 

--- a/Patches/Enforcer/ThingDefs_Misc/Weapons.xml
+++ b/Patches/Enforcer/ThingDefs_Misc/Weapons.xml
@@ -76,6 +76,7 @@
                     <SwayFactor>1.4</SwayFactor>
                     <Bulk>13</Bulk>
                     <Mass>8</Mass>
+                    <ToughnessRating>3.606</ToughnessRating>
                     <RangedWeapon_Cooldown>1</RangedWeapon_Cooldown>
                 </statBases>
                     
@@ -104,6 +105,7 @@
                     <SwayFactor>1.4</SwayFactor>
                     <Bulk>13</Bulk>
                     <Mass>8</Mass>
+                    <ToughnessRating>3.606</ToughnessRating>
                     <RangedWeapon_Cooldown>0.5</RangedWeapon_Cooldown>
                 </statBases>
                     

--- a/Patches/Eveliet Race/ThingDefs_Misc/Weapons.xml
+++ b/Patches/Eveliet Race/ThingDefs_Misc/Weapons.xml
@@ -34,6 +34,14 @@
 					</value>
 				</li>
 
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="HAR_EL_Weapon_a"]/statBases</xpath>
+					<value>
+						<Bulk>10</Bulk>
+						<ToughnessRating>25.298</ToughnessRating>
+					</value>
+				</li>
+
 			</operations>
 			</match>
 			</li>

--- a/Patches/Idearn Race/ThingDefs_Misc/Weapons.xml
+++ b/Patches/Idearn Race/ThingDefs_Misc/Weapons.xml
@@ -25,6 +25,14 @@
 						</tools>
 					</value>
 				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="HAR_IA_Item_ArcheCartridge"]/statBases</xpath>
+					<value>
+						<Bulk>1</Bulk>
+						<ToughnessRating>4</ToughnessRating>
+					</value>
+				</li>
 			</operations>
 			</match>
 			</li>

--- a/Patches/Nearmare/ThingDefs_Misc/Weapons.xml
+++ b/Patches/Nearmare/ThingDefs_Misc/Weapons.xml
@@ -47,6 +47,14 @@
                             </tools>
                     </value>
 				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="HAR_NM_Weapon_Sword_a"]/statBases</xpath>
+					<value>
+						<Bulk>8</Bulk>
+						<StuffEffectMultiplierToughness>5.657</StuffEffectMultiplierToughness>
+					</value>
+				</li>
 				
                 <!--========= Ts'vaot Rifle =========-->
 				<li Class="PatchOperationReplace">
@@ -75,6 +83,7 @@
                         <ShotSpread>1</ShotSpread>
                         <SwayFactor>1.3</SwayFactor>
                         <Mass>3.5</Mass>
+                        <ToughnessRating>5.158</ToughnessRating>
                         <RangedWeapon_Cooldown>0.25</RangedWeapon_Cooldown>
                     </statBases>
 
@@ -144,6 +153,7 @@
                         <ShotSpread>0.2</ShotSpread>
                         <SwayFactor>1.35</SwayFactor>
                         <Mass>3.5</Mass>
+                        <ToughnessRating>6.325</ToughnessRating>
                         <RangedWeapon_Cooldown>0.99</RangedWeapon_Cooldown>
                     </statBases>
 
@@ -215,6 +225,13 @@
 
                 <li Class="PatchOperationRemove">
 				   <xpath>Defs/ThingDef[defName="Gun_AssaultRifle_NM"]/comps/li[@Class="CombatExtended.CompProperties_AmmoUser"]</xpath>
+                </li>
+
+                <li Class="PatchOperationAdd">
+                    <xpath>Defs/ThingDef[defName="Gun_AssaultRifle_NM"]/statBases</xpath>
+                    <value>
+                        <ToughnessRating>5.158</ToughnessRating>
+                    </value>
                 </li>
 
 			</operations>

--- a/Patches/Outerm/ThingDefs_Misc/Weapons.xml
+++ b/Patches/Outerm/ThingDefs_Misc/Weapons.xml
@@ -36,6 +36,16 @@
 							</value>
 						</li>
 
+						<li Class="PatchOperationAdd">
+							<xpath>Defs/ThingDef[defName="HAR_OT_Weapon_a"]</xpath>
+							<value>
+								<statBases>
+									<Bulk>3.5</Bulk>
+									<ToughnessRating>3.742</ToughnessRating>
+								</statBases>
+							</value>
+						</li>
+
 						<li Class="PatchOperationReplace">
 							<xpath>Defs/ThingDef[defName="HAR_OT_Weapon_b"]/tools</xpath>
 							<value>
@@ -68,6 +78,16 @@
 							</value>
 						</li>
 
+						<li Class="PatchOperationAdd">
+							<xpath>Defs/ThingDef[defName="HAR_OT_Weapon_b"]</xpath>
+							<value>
+								<statBases>
+									<Bulk>4</Bulk>
+									<ToughnessRating>4</ToughnessRating>
+								</statBases>
+							</value>
+						</li>
+
 						<li Class="PatchOperationReplace">
 							<xpath>Defs/ThingDef[defName="HAR_OT_Weapon_c"]/tools</xpath>
 							<value>
@@ -97,6 +117,16 @@
 							<xpath>Defs/ThingDef[defName="HAR_OT_Weapon_c"]/equippedStatOffsets/ArmorRating_Sharp</xpath>
 							<value>
 								<ArmorRating_Sharp>16</ArmorRating_Sharp>
+							</value>
+						</li>
+
+						<li Class="PatchOperationAdd">
+							<xpath>Defs/ThingDef[defName="HAR_OT_Weapon_c"]</xpath>
+							<value>
+								<statBases>
+									<Bulk>4</Bulk>
+									<ToughnessRating>4</ToughnessRating>
+								</statBases>
 							</value>
 						</li>
 
@@ -166,6 +196,7 @@
 								<SwayFactor>1.0</SwayFactor>
 								<Bulk>9</Bulk>
 								<Mass>3.5</Mass>
+								<ToughnessRating>3</ToughnessRating>
 								<RangedWeapon_Cooldown>0.35</RangedWeapon_Cooldown>
 							</statBases>
 							<Properties>
@@ -203,6 +234,7 @@
 								<SwayFactor>1.1</SwayFactor>
 								<Bulk>12</Bulk>
 								<Mass>3.5</Mass>
+								<ToughnessRating>3.464</ToughnessRating>
 								<RangedWeapon_Cooldown>2.3</RangedWeapon_Cooldown>
 							</statBases>
 							<Properties>

--- a/Patches/Qualeela Race/ThingDefs_Misc/Weapons.xml
+++ b/Patches/Qualeela Race/ThingDefs_Misc/Weapons.xml
@@ -18,6 +18,7 @@
 					<SwayFactor>2</SwayFactor>
 					<Bulk>6.65</Bulk>
 					<Mass>3.3</Mass>
+					<ToughnessRating>20.631</ToughnessRating>
 					<RangedWeapon_Cooldown>1</RangedWeapon_Cooldown>
 				</statBases>
 				
@@ -85,6 +86,7 @@
 					<ShotSpread>0.1</ShotSpread>
 					<SwayFactor>1.4</SwayFactor>
 					<Mass>3.3</Mass>
+					<ToughnessRating>20.631</ToughnessRating>
 					<RangedWeapon_Cooldown>1</RangedWeapon_Cooldown>
 				</statBases>
 				

--- a/Patches/Requeen/ThingDefs_Misc/Weapons.xml
+++ b/Patches/Requeen/ThingDefs_Misc/Weapons.xml
@@ -44,6 +44,7 @@
                         <SwayFactor>0.9</SwayFactor>
                         <Bulk>13</Bulk>
                         <Mass>8</Mass>
+                        <ToughnessRating>3.606</ToughnessRating>
                         <RangedWeapon_Cooldown>3.5</RangedWeapon_Cooldown>
                     </statBases>
                         
@@ -79,6 +80,7 @@
                         <SwayFactor>1.9</SwayFactor>
                         <Bulk>13</Bulk>
                         <Mass>9</Mass>
+                        <ToughnessRating>3.606</ToughnessRating>
                         <RangedWeapon_Cooldown>15</RangedWeapon_Cooldown>
                     </statBases>
                         
@@ -112,6 +114,7 @@
                         <SwayFactor>1</SwayFactor>
                         <Bulk>5</Bulk>
                         <Mass>8</Mass>
+                        <ToughnessRating>2.236</ToughnessRating>
                         <RangedWeapon_Cooldown>8</RangedWeapon_Cooldown>
                     </statBases>
                         
@@ -148,6 +151,7 @@
                         <SwayFactor>1.3</SwayFactor>
                         <Bulk>10</Bulk>
                         <Mass>3</Mass>
+                        <ToughnessRating>3.162</ToughnessRating>
                         <RangedWeapon_Cooldown>0.5</RangedWeapon_Cooldown>
                     </statBases>
                         
@@ -180,6 +184,7 @@
                         <SwayFactor>0.1</SwayFactor>
                         <Bulk>10</Bulk>
                         <Mass>3</Mass>
+                        <ToughnessRating>3.162</ToughnessRating>
                         <RangedWeapon_Cooldown>2</RangedWeapon_Cooldown>
                     </statBases>
                         

--- a/Patches/Solark Race/ThingDefs_Races/AlienRace_Solark.xml
+++ b/Patches/Solark Race/ThingDefs_Races/AlienRace_Solark.xml
@@ -52,6 +52,7 @@
 				  <value>
 					<Suppressability>0.2</Suppressability>
 					<SmokeSensitivity>0.2</SmokeSensitivity>
+					<NightVisionEfficiency>0.2</NightVisionEfficiency>
 					<MeleeCritChance>1.0</MeleeCritChance>
 					<MeleeParryChance>1.0</MeleeParryChance>
 				  </value>

--- a/Patches/Xenoorca Race/ThingDefs_Misc/Weapons.xml
+++ b/Patches/Xenoorca Race/ThingDefs_Misc/Weapons.xml
@@ -42,6 +42,14 @@
 					</value>
 				</li>
 
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="HAR_XO_Weapon_a"]/statBases</xpath>
+					<value>
+						<Bulk>10</Bulk>
+						<ToughnessRating>6.325</ToughnessRating>
+					</value>
+				</li>
+
 			</operations>
 			</match>
 			</li>

--- a/Patches/Zoichor/ThingDefs_Misc/Weapons.xml
+++ b/Patches/Zoichor/ThingDefs_Misc/Weapons.xml
@@ -32,6 +32,14 @@
 				</value>
 			</li>
 
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="HAR_ZC_Weapon_a"]/statBases</xpath>
+				<value>
+					<Bulk>10</Bulk>
+					<ToughnessRating>25.298</ToughnessRating>
+				</value>
+			</li>
+
 			</operations>
 			</match>
 			</li>


### PR DESCRIPTION
add missing CE toughness and bulk tuning to Aya weapon patches across several races
add the two small race stat updates that were part of the isolated substantive diff